### PR TITLE
Bug fixes and Puppet 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 5.0"
 
 notifications:
-email: false
+  email: false

--- a/Modulefile
+++ b/Modulefile
@@ -2,7 +2,7 @@ name 'kreczko-argus'
 version '0.0.1'
 
 author 'kreczko'
-license 'Apache License 2.0'
+license 'Apache-2.0'
 project_page 'https://github.com/HEP-Puppet'
 source 'git@github.com:HEP-Puppet/puppet-argus.git'
 summary 'Puppet module for Argus server'

--- a/Modulefile
+++ b/Modulefile
@@ -2,7 +2,7 @@ name 'kreczko-argus'
 version '0.0.1'
 
 author 'kreczko'
-license 'Apache License, Version 2.0'
+license 'Apache License 2.0'
 project_page 'https://github.com/HEP-Puppet'
 source 'git@github.com:HEP-Puppet/puppet-argus.git'
 summary 'Puppet module for Argus server'

--- a/examples/argus_server.yaml
+++ b/examples/argus_server.yaml
@@ -1,5 +1,6 @@
 argus_server::argus_host: '<argus_host_fqdn>'
 argus_server::argus_host_dn: '<argus_host_dn>'
+argus_server::admin_password: '<admin_password>'
 argus_server::centralban_enabled: 'true'
 argus_server::centralban_host: '<central_ban_host>'
 argus_server::centralban_dn: '<central_ban_host_dn>'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class argus_server::config(
   $centralban_dn      = $argus_server::centralban_dn,
   $centralban_host    = $argus_server::centralban_host,
   $pap_poll_interval  = $argus_server::pap_poll_interval,
+  $admin_password     = $argus_server::admin_password,
 ) {
 
   # ARGUS configuration files

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,12 @@
 # Class: arc_ce
 # Sets up the configuration file and file dependencies.
-class argus_server::config {
+class argus_server::config(
+  $argus_host         = $argus_server::argus_host,
+  $centralban_enabled = $argus_server::centralban_enabled,
+  $centralban_dn      = $argus_server::centralban_dn,
+  $centralban_host    = $argus_server::centralban_host,
+  $pap_poll_interval  = $argus_server::pap_poll_interval,
+) {
 
   # ARGUS configuration files
   file { '/etc/argus/pap/pap-admin.properties':
@@ -10,7 +16,7 @@ class argus_server::config {
     mode    => '0640',
     content => template("${module_name}/pap-admin.properties.erb"),
     notify  => Service['argus-pap'],
-  }    
+  }
 
   file { '/etc/argus/pap/pap_configuration.ini':
     ensure  => 'present',
@@ -19,7 +25,7 @@ class argus_server::config {
     mode    => '0640',
     content => template("${module_name}/pap_configuration.ini.erb"),
     notify  => Service['argus-pap'],
-  }    
+  }
 
   file { '/etc/argus/pdp/pdp.ini':
     ensure  => 'present',
@@ -28,7 +34,7 @@ class argus_server::config {
     mode    => '0640',
     content => template("${module_name}/pdp.ini.erb"),
     notify  => Service['argus-pdp'],
-  }    
+  }
 
   file { '/etc/argus/pepd/pepd.ini':
     ensure  => 'present',
@@ -37,5 +43,5 @@ class argus_server::config {
     mode    => '0640',
     content => template("${module_name}/pepd.ini.erb"),
     notify  => Service['argus-pepd'],
-  }    
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@ class argus_server (
   $centralban_enabled     = false,
   $centralban_host        = 'argusngi.gridpp.rl.ac.uk',
   $centralban_dn          = '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=argusngi.gridpp.rl.ac.uk',
+  $servicecert            = '/etc/grid-security/hostcert.pem',
+  $servicekey             = '/etc/grid-security/hostkey.pem',
 ){
 
   case $facts['os']['family'] {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,17 +11,30 @@
 # Sample Usage:
 #
 class argus_server (
-  $packages = ['java-1.8.0-openjdk', 'argus-authz', 'bdii', 'glite-info-provider-service'],
-  $argus_host = '',
-  $argus_host_dn = '',
-  $pap_poll_interval = 3600,
-  $pdp_retention_interval = 240,  
-  $pap_policy = {},
-  $centralban_enabled = 'false',
-  $centralban_host = 'argusngi.gridpp.rl.ac.uk',
-  $centralban_dn = '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=argusngi.gridpp.rl.ac.uk',
+  $argus_host_dn,
+  $admin_password,
+  $argus_host             = $::fqdn,
+  $packages               = ['java-1.8.0-openjdk', 'argus-authz', 'bdii', 'glite-info-provider-service'],
+  $pap_poll_interval      = 3600,
+  $pdp_retention_interval = 240,
+  $pap_policy             = {},
+  $centralban_enabled     = 'false',
+  $centralban_host        = 'argusngi.gridpp.rl.ac.uk',
+  $centralban_dn          = '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=argusngi.gridpp.rl.ac.uk',
 ){
-  
+
+  case $facts['os']['family'] {
+    'RedHat': {
+      case $facts['os']['release']['major'] {
+        '6': { $restart_cmd = '/sbin/service argus-pap restart; /sbin/service argus-pdp restart; /sbin/service argus-pepd restart' }
+        default: { $restart_cmd = '/usr/bin/systemctl restart argus-pap argus-pdp argus-pepd' }
+      }
+    }
+    default: {
+      fail("OS family ${facts['os']['family']} is not supported by this module")
+    }
+  }
+
   class { 'argus_server::install': }
   class { 'argus_server::config': }
   class { 'argus_server::services': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class argus_server (
   $pap_poll_interval      = 3600,
   $pdp_retention_interval = 240,
   $pap_policy             = {},
-  $centralban_enabled     = 'false',
+  $centralban_enabled     = false,
   $centralban_host        = 'argusngi.gridpp.rl.ac.uk',
   $centralban_dn          = '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=argusngi.gridpp.rl.ac.uk',
 ){

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,5 +3,5 @@ class argus_server::install {
     package { $argus_server::packages:
       ensure => 'present',
     }
- 
+
 }

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -1,8 +1,7 @@
-class argus_server::policy {
+class argus_server::policy(
+  $pap_policy = $argus_server::pap_policy,
+) {
 
-  $restart_cmd='service argus-pap restart; service argus-pdp restart; service argus-pepd restart'
-
-  notify { "$restart_cmd":}
   # XML policy to load
   file { '/etc/argus/argus_policy.xml':
     ensure  => 'present',
@@ -15,14 +14,14 @@ class argus_server::policy {
   # Restart argus if needed
   exec {'ssl restart':
     path => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command => $restat_cmd,
+    command => $argus_server::restart_cmd,
     onlyif  => 'pap-admin lp | grep -q SSL',
   }
 
   # Load the policy
   exec { 'apply argus policy':
     path => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command     => "sleep 60; pap-admin add-policies-from-file /etc/argus/argus_policy.xml; $restart_cmd",
+    command     => "sleep 60; pap-admin add-policies-from-file /etc/argus/argus_policy.xml; ${argus_server::restart_cmd}",
     onlyif      => "bash -c \"[[ -r /etc/argus/argus_policy.xml ]] && pap-admin lp | grep -q 'No policies'\"",
     logoutput   => true, #"on_failure", # "true"
     require     => Exec['ssl restart']
@@ -36,6 +35,5 @@ class argus_server::policy {
     logoutput   => true, #"on_failure", # "true"
     subscribe   => File['/etc/argus/argus_policy.xml'],
   }
-        
 
-}              
+}

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -13,14 +13,14 @@ class argus_server::policy(
 
   # Restart argus if needed
   exec {'ssl restart':
-    path => '/usr/bin:/bin:/usr/sbin:/sbin',
+    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
     command => $argus_server::restart_cmd,
     onlyif  => 'pap-admin lp | grep -q SSL',
   }
 
   # Load the policy
   exec { 'apply argus policy':
-    path => '/usr/bin:/bin:/usr/sbin:/sbin',
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
     command     => "sleep 60; pap-admin add-policies-from-file /etc/argus/argus_policy.xml; ${argus_server::restart_cmd}",
     onlyif      => "bash -c \"[[ -r /etc/argus/argus_policy.xml ]] && pap-admin lp | grep -q 'No policies'\"",
     logoutput   => true, #"on_failure", # "true"
@@ -29,7 +29,7 @@ class argus_server::policy(
 
   # Load the policy
   exec { 'refresh argus policy':
-    path => '/usr/bin:/bin:/usr/sbin:/sbin',
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
     command     => 'pap-admin add-policies-from-file /etc/argus/argus_policy.xml',
     refreshonly => true,
     logoutput   => true, #"on_failure", # "true"

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -20,11 +20,11 @@ class argus_server::policy(
 
   # Load the policy
   exec { 'apply argus policy':
-    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command     => "sleep 60; pap-admin add-policies-from-file /etc/argus/argus_policy.xml; ${argus_server::restart_cmd}",
-    onlyif      => "bash -c \"[[ -r /etc/argus/argus_policy.xml ]] && pap-admin lp | grep -q 'No policies'\"",
-    logoutput   => true, #"on_failure", # "true"
-    require     => Exec['ssl restart']
+    path      => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command   => "sleep 60; pap-admin add-policies-from-file /etc/argus/argus_policy.xml; ${argus_server::restart_cmd}",
+    onlyif    => "bash -c \"[[ -r /etc/argus/argus_policy.xml ]] && pap-admin lp | grep -q 'No policies'\"",
+    logoutput => true, #"on_failure", # "true"
+    require   => Exec['ssl restart']
   }
 
   # Load the policy

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -1,4 +1,7 @@
-class argus_server::services {
+class argus_server::services(
+  $servicecert = $argus_server::servicecert,
+  $servicekey  = $argus_server::servicekey,
+) {
 
   exec { 'run fetch-crl':
     # fetch-crl returns false if there's a problem with any of the CAs and therefore blocking
@@ -12,8 +15,8 @@ class argus_server::services {
     command     => $argus_server::restart_cmd,
     refreshonly => true,
     subscribe   => [
-      File['/etc/grid-security/hostcert.pem'],
-      File['/etc/grid-security/hostkey.pem'],
+      File[$servicecert],
+      File[$servicekey],
     ],
   }
 

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -3,39 +3,39 @@ class argus_server::services {
   exec { 'run fetch-crl':
     # fetch-crl returns false if there's a problem with any of the CAs and therefore blocking
     # any further argus configuration, ignore return value to avoid this (always return true)
-    command     => '/usr/sbin/fetch-crl || true',
-    require     => Class['fetchcrl::install'],
-    unless      => '/bin/ls /etc/grid-security/certificates/*.r0 1>/dev/null 2>&1'
+    command => '/usr/sbin/fetch-crl || true',
+    require => Class['fetchcrl::install'],
+    unless  => '/bin/ls /etc/grid-security/certificates/*.r0 1>/dev/null 2>&1'
   }
 
   exec { 'hostcert update':
-    command   => '/usr/bin/systemctl restart argus-pap argus-pdp argus-pepd',
+    command     => $argus_server::restart_cmd,
     refreshonly => true,
-    subscribe => [
+    subscribe   => [
       File['/etc/grid-security/hostcert.pem'],
       File['/etc/grid-security/hostkey.pem'],
     ],
   }
 
   service { 'argus-pap':
-    ensure     => running,
+    ensure     => 'running',
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    require     => Exec['run fetch-crl'],
-    notify => Service['argus-pdp'],
+    require    => Exec['run fetch-crl'],
+    notify     => Service['argus-pdp'],
   }
-  
+
   service { 'argus-pdp':
-    ensure     => running,
+    ensure     => 'running',
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    notify => Service['argus-pepd'],
+    notify     => Service['argus-pepd'],
   }
 
   service { 'argus-pepd':
-    ensure     => running,
+    ensure     => 'running',
     enable     => true,
     hasrestart => true,
     hasstatus  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "kreczko-argus",
   "author": "kreczko",
   "description": "Puppet module for Argus server",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "project_page": "https://github.com/HEP-Puppet",
   "source": "git@github.com:HEP-Puppet/puppet-argus.git",
   "summary": "Puppet module for Argus server",

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "kreczko-argus",
   "author": "kreczko",
   "description": "Puppet module for Argus server",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache License 2.0",
   "project_page": "https://github.com/HEP-Puppet",
   "source": "git@github.com:HEP-Puppet/puppet-argus.git",
   "summary": "Puppet module for Argus server",

--- a/templates/pdp.ini.erb
+++ b/templates/pdp.ini.erb
@@ -26,7 +26,7 @@ entityId = http://<%= @argus_host %>/pdp
 hostname = <%= @argus_host %>
 port = 8152
 adminPort = 8153
-adminPassword = pdpadmin_<%= @admin_password %>
+adminPassword = <%= @admin_password %>
 
 [POLICY]
 paps = https://<%= @argus_host %>:8150/pap/services/ProvisioningService

--- a/templates/pdp.ini.erb
+++ b/templates/pdp.ini.erb
@@ -26,7 +26,7 @@ entityId = http://<%= @argus_host %>/pdp
 hostname = <%= @argus_host %>
 port = 8152
 adminPort = 8153
-adminPassword = pdpadmin_<%= @facts['uniqueid'] %>
+adminPassword = pdpadmin_<%= @admin_password %>
 
 [POLICY]
 paps = https://<%= @argus_host %>:8150/pap/services/ProvisioningService

--- a/templates/pepd.ini.erb
+++ b/templates/pepd.ini.erb
@@ -26,7 +26,7 @@ entityId = http://<%= @argus_host %>/pepd
 hostname = <%= @argus_host %>
 port = 8154
 adminPort = 8155
-adminPassword = pepdadmin_<%= @facts['uniqueid'] %>
+adminPassword = pepdadmin_<%= @admin_password %>
 
 # PIPs to apply on incoming request
 pips = REQVALIDATOR_PIP OPENSSLSUBJECT_PIP GLITEXACMLPROFILE_PIP COMMONXACMLPROFILE_PIP
@@ -73,6 +73,6 @@ acceptedProfileIDs = http://dci-sec.org/xacml/profile/common-authz/1.1
 #
 [ACCOUNTMAP_OH]
 parserClass = org.glite.authz.pep.obligation.dfpmap.DFPMObligationHandlerConfigurationParser
-accountMapFile = /etc/grid-security/grid-mapfile 
+accountMapFile = /etc/grid-security/grid-mapfile
 groupMapFile = /etc/grid-security/groupmapfile
 gridMapDir = /etc/grid-security/gridmapdir

--- a/templates/pepd.ini.erb
+++ b/templates/pepd.ini.erb
@@ -26,7 +26,7 @@ entityId = http://<%= @argus_host %>/pepd
 hostname = <%= @argus_host %>
 port = 8154
 adminPort = 8155
-adminPassword = pepdadmin_<%= @admin_password %>
+adminPassword = <%= @admin_password %>
 
 # PIPs to apply on incoming request
 pips = REQVALIDATOR_PIP OPENSSLSUBJECT_PIP GLITEXACMLPROFILE_PIP COMMONXACMLPROFILE_PIP


### PR DESCRIPTION
There's a new mandatory parameter to set that admin password and the default value of the argus_host_dn parameter was removed, so it's mandatory as well now.